### PR TITLE
New "product process" labels

### DIFF
--- a/labels.yml
+++ b/labels.yml
@@ -83,6 +83,6 @@ labels:
     description: We agree on the interaction and are debating visual treatments: colors, spacing, etc.
     color: '6322AF'
 
-  - name: dependent
+  - name: blocked
     description: We can't work on this task until another task is complete.
     color: '555555'

--- a/labels.yml
+++ b/labels.yml
@@ -1,8 +1,4 @@
 labels:
-  - name: brainstorm
-    description: "Is this actually a problem? Should we solve it?"
-    color: '7d7d7d'
-
   - name: ready
     description: Ready for a developer to start implementation
     color: '00c94d'

--- a/labels.yml
+++ b/labels.yml
@@ -31,18 +31,6 @@ labels:
     description:
     color: '627ada'
 
-  - name: sat_basic_expectation
-    description: Customers hate us for not having this.
-    color: 'b09a87'
-
-  - name: sat_delighter
-    description: Customers will love us for this.
-    color: '45ffc7'
-
-  - name: sat_standard
-    description: Customer satisfaction is directly proportional to our investment.
-    color: '530178'
-
   - name: security
     description:
     color: '3b4047'
@@ -82,3 +70,23 @@ labels:
 
   - name: est_8
     color: '464B6D'
+
+  - name: p_outcome
+    description: Is this an actual user need? Or: we're not yet sure what the need is.
+    color: 'FE95F4'
+
+  - name: p_structure
+    description: We agree that the outcome makes sense and are deciding how to fulfill it.
+    color: 'D46DD8'
+
+  - name: p_interaction
+    description: We know how we want to solve the problem and are discussing wireframes or rough mockups.
+    color: '9341AF'
+
+  - name: p_visual
+    description: We agree on the interaction and are debating visual treatments: colors, spacing, etc.
+    color: '6322AF'
+
+  - name: dependent
+    description: We can't work on this task until another task is complete.
+    color: '555555'


### PR DESCRIPTION
Since we first created this repo, I've found that our process-specific labels need some work.

- For dormant issues, the `brainstorm` label isn't helpful for understanding how much work is needed to mark it as `ready`. You have to read the entire thread to understand whether we're hung up over an interaction detail, or questioning an idea's underlying assumptions.

- For issues we're actively discussing, the `brainstorm` label doesn't clarify what stage of the design process we're in. This sometimes leads to painful miscommunication, where one person wants to move ahead with a solution while the other is still questioning the outcome. 

- There is no way to indicate an issue is dependent on another issue's completion. This messes up our estimates.

- The [Kano model](https://articles.uie.com/kano_model/), where we categorize issues as `basic expectation` / `standard` / `delighters`, is helpful for communicating our perception of customer impact. But they're useless for prioritization, as most will fall under `standard`. And issues can rapidly change (from `standard` to `basic` and back again) as we synthesize customer feedback, and better understand the market.

So, this PR...

- Removes the `brainstorm` label in favor of `p_outcome`, `p_structure`, `p_interaction`, and `p_visual` labels. We can use these as a communication tool during active discussion, and a reference for dormant threads.

- Adds a `dependent` label for dependent tasks

- Removes the `sat_` labels. Especially for minor tasks, estimates of an issue's impact on customers can vary wildly each week depending on external factors. We can prioritize issues in ordered milestones, as well as roadmap docs external to Github.