### PR TITLE
Add a "partial" label

### DIFF
--- a/labels.yml
+++ b/labels.yml
@@ -87,6 +87,6 @@ labels:
     description: We can't work on this task until another task is complete.
     color: '555555'
 
-  - name: partial
+  - name: partial_solution
     description: This is an easier workaround to accomplish part of the outcome for a large, difficult task.
     color: 'FFEDB3'

--- a/labels.yml
+++ b/labels.yml
@@ -86,3 +86,7 @@ labels:
   - name: blocked
     description: We can't work on this task until another task is complete.
     color: '555555'
+
+  - name: partial
+    description: This is an easier workaround to accomplish part of the outcome for a large, difficult task.
+    color: 'FFEDB3'


### PR DESCRIPTION
When I was re-organizing our Screendoor repo, I found that our labels worked really well, except for one problem. There's no way to indicate that an issue doesn't describe a new user need, but rather is an idea for partially fulfilling a need with low-to-medium effort. If we only shipped the difficult task, we could also close the easier task, but not vice versa.

Two examples:

- [This issue](https://github.com/dobtco/screendoor-v2/issues/3927) makes it easier for ProPublica to use messages to ask respondents for follow-up info. But what they really need are follow-up forms.

- I suggested that we [rename some of our merge variables](https://github.com/dobtco/screendoor-v2/issues/3756), because a more polished [autocomplete feature](https://github.com/dobtco/screendoor-v2/issues/749) is difficult to implement. 

I wasn't sure what to name this label, but I came up with "partial." Open to better ideas.